### PR TITLE
Make it possible to pass the wsdl literally to the SoapClient.

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -16,21 +16,28 @@ class Factory
      * Create an instance of SoapClientInterface asynchronously.
      *
      * @param ClientInterface $client       A Guzzle HTTP client.
-     * @param mixed $wsdl                   URI of the WSDL file or NULL if working in non-WSDL mode.
+     * @param mixed $wsdlOrWsdlUrl          WSDL or URI of the WSDL file or NULL if working in non-WSDL mode.
      * @param array $options                Supported options: location, uri, style, use, soap_version, encoding,
      *                                      exceptions, classmap, typemap, and feature. HTTP related options should
      *                                      be configured against $client, e.g., authentication, proxy, user agent,
      *                                      and connection timeout etc.
      * @return SoapClientInterface
      */
-    public function create(ClientInterface $client, $wsdl, array $options = [])
+    public function create(ClientInterface $client, $wsdlOrWsdlUrl, array $options = [])
     {
-        if (null === $wsdl) {
+        if (null === $wsdlOrWsdlUrl) {
             $httpBindingPromise = new FulfilledPromise(
-                new HttpBinding(new Interpreter($wsdl, $options), new RequestBuilder)
+                new HttpBinding(new Interpreter($wsdlOrWsdlUrl, $options), new RequestBuilder)
+            );
+        } elseif ('<' === $wsdlOrWsdlUrl[0]) {
+            $httpBindingPromise = new FulfilledPromise(
+                new HttpBinding(
+                    new Interpreter('data://text/plain;base64,' . base64_encode($wsdlOrWsdlUrl), $options),
+                    new RequestBuilder
+                )
             );
         } else {
-            $httpBindingPromise = $client->requestAsync('GET', $wsdl)->then(
+            $httpBindingPromise = $client->requestAsync('GET', $wsdlOrWsdlUrl)->then(
                 function (ResponseInterface $response) use ($options) {
                     $wsdl = $response->getBody()->__toString();
                     $interpreter = new Interpreter('data://text/plain;base64,' . base64_encode($wsdl), $options);

--- a/tests/functional/SoapClientTest.php
+++ b/tests/functional/SoapClientTest.php
@@ -28,6 +28,23 @@ class SoapClientTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function callWithWsdlContentPassedInLiterally()
+    {
+        $guzzleClient = new Client();
+        $wsdl = $guzzleClient->get('http://www.webservicex.net/Statistics.asmx?WSDL')->getBody()->getContents();
+
+        $client = $this->factory->create(
+            new Client(),
+            $wsdl
+        );
+        $response = $client->call('GetStatistics', [['X' => [1,2,3]]]);
+
+        $this->assertNotEmpty($response);
+    }
+
+    /**
+     * @test
      * @dataProvider webServicesProvider
      */
     public function callAsync($wsdl, $options, $function, $args, $contains)

--- a/tests/unit/FactoryTest.php
+++ b/tests/unit/FactoryTest.php
@@ -24,6 +24,33 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function wsdlMode()
     {
+        $wsdl = $this->getTestWsdl();
+
+        $factory = new Factory();
+        $handlerMock = new MockHandler([new Response('200', [], $wsdl)]);
+        $handler = new HandlerStack($handlerMock);
+        $clientMock = new Client(['handler' => $handler]);
+        $client = $factory->create($clientMock, 'wsdl');
+        $this->assertTrue($client instanceof SoapClient);
+
+    }
+
+    /**
+     * @test
+     */
+    public function acceptWsdlContentToBePassedIn()
+    {
+        $wsdl = $this->getTestWsdl();
+        $factory = new Factory();
+        $clientMock = new Client();
+
+        $soapClient = $factory->create($clientMock, $wsdl);
+
+        $this->assertTrue($soapClient instanceof SoapClient);
+    }
+
+    private function getTestWsdl()
+    {
         // this wsdl adapted from https://www.w3.org/2001/04/wsws-proceedings/uche/wsdl.html
         $wsdl = <<<EOD
 <definitions name="EndorsementSearch"
@@ -84,12 +111,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 </definitions>
 EOD;
 
-        $factory = new Factory();
-        $handlerMock = new MockHandler([new Response('200', [], $wsdl)]);
-        $handler = new HandlerStack($handlerMock);
-        $clientMock = new Client(['handler' => $handler]);
-        $client = $factory->create($clientMock, 'wsdl');
-        $this->assertTrue($client instanceof SoapClient);
-
+        return $wsdl;
     }
 }


### PR DESCRIPTION
This allows devs to obtain the wsdl from anywhere they want (cache or from file) and not call the remote soap service to get the wsdl every time the soap client is used.

Btw. many thanks for this library. It's immensely useful.
