### PR TITLE
Deprecated parameters removed

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -46,7 +46,7 @@ class Factory
 
     private function isHttpUrl($wsdl)
     {
-        return filter_var($wsdl, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED) !== false
+        return filter_var($wsdl, FILTER_VALIDATE_URL) !== false
             && in_array(parse_url($wsdl, PHP_URL_SCHEME), ['http', 'https']);
     }
 }


### PR DESCRIPTION
From PHP 7.3.0 `FILTER_FLAG_SCHEME_REQUIRED` is deprecated, because it's implicitly applied by `FILTER_VALIDATE_URL`.


> 7.3.0 | Deprecated explicit usage of FILTER_FLAG_HOST_REQUIRED and FILTER_FLAG_SCHEME_REQUIRED. They are implied for FILTER_VALIDATE_URL
> ...
> 5.2.1 | FILTER_VALIDATE_URL now implicitly uses FILTER_FLAG_SCHEME_REQUIRED andFILTER_FLAG_HOST_REQUIRED.

From the [docs](http://php.net/manual/en/filter.filters.validate.php).