### PR TITLE
Do not close request & response streams

### DIFF
--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -50,8 +50,6 @@ class SoapClient implements SoapClientInterface
                     } else {
                         throw $exception;
                     }
-                } finally {
-                    $request->getBody()->close();
                 }
             }
         );
@@ -59,10 +57,6 @@ class SoapClient implements SoapClientInterface
 
     private function interpretResponse(HttpBinding $httpBinding, ResponseInterface $response, $name, &$outputHeaders)
     {
-        try {
-            return $httpBinding->response($response, $name, $outputHeaders);
-        } finally {
-            $response->getBody()->close();
-        }
+        return $httpBinding->response($response, $name, $outputHeaders);
     }
 }


### PR DESCRIPTION
Streams should not be closed as they can be required after the http calls end. This gives the flexibility to re-read the request & response bodies.