### PR TITLE
Fix empty response body

### DIFF
--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -59,10 +59,6 @@ class SoapClient implements SoapClientInterface
 
     private function interpretResponse(HttpBinding $httpBinding, ResponseInterface $response, $name, &$outputHeaders)
     {
-        try {
-            return $httpBinding->response($response, $name, $outputHeaders);
-        } finally {
-            $response->getBody()->close();
-        }
+        return $httpBinding->response($response, $name, $outputHeaders);
     }
 }

--- a/tests/unit/SoapClientTest.php
+++ b/tests/unit/SoapClientTest.php
@@ -253,8 +253,8 @@ class SoapClientTest extends TestCase
         $this->assertEquals($magicResult, $asyncResult);
         $this->assertEquals($syncResult, $asyncResult);
 
-        $this->assertEquals($magicResult, $body);
-        $this->assertEquals($asyncResult, $body);
-        $this->assertEquals($syncResult, $body);
+        $this->assertEquals($body, $magicResult);
+        $this->assertEquals($body, $asyncResult);
+        $this->assertEquals($body, $syncResult);
     }
 }


### PR DESCRIPTION
Hello friend how are you doing. Im doing well. Nice work on the package Its really seeing a lot of popularity in the PHP commmunity and should really be considered the de-facto package for dealing with soap asynchronously. I recently have been using it for work and one of our clients noticed some issues with responses coming back empty. We firstly suspected that the server is not sending back any valid responses until the client gave us log output indicating the issue. Based on this I had a look at what was going wrong and found this. I will explain it in the overview.

## Overview

### Problem
So the main issue was that the response object returned by guzzle become empty by the second call with the client and we were all wondering why I first decided to add a var dump in order to show this issue and run the test `\Meng\AsyncSoap\Guzzle\SoapClientTest::resultsAreEquivalent` I put the following `var_dump` just after line https://github.com/meng-tian/async-soap-guzzle/blob/master/src/SoapClient.php#L44 

```php
//...
$response = (yield $this->client->sendAsync($request, $requestOptions));
var_dump($response->getBody()->__toString());
yield $this->interpretResponse($httpBinding, $response, $name, $outputHeaders);
//...
```

And I noticed that on the first call we end up with the desired `'body'` string only once consecutive calls were resulting in an empty string `''`. So in order to further expose the issue updated the test `\Meng\AsyncSoap\Guzzle\SoapClientTest::resultsAreEquivalent` such that instead of just returning the `SoapResult` string we instead return the body of the request (just to simplify what we put in we get out). This resulted in the failing test that exposed the issue.

### Fix

In order to fix this I went on to remove the finally block in the function call `SoapClient::interpretResponse` this was mainly cause the block will be called after the return and will effectively close the stream on the response body. This stream will be closed not just for the current response but all consecutive responses maybe because the stream is a resource in the location `php://temp` but once I removed that block it worked. Feel free to let me know what you think about this as it seems that it might help.


